### PR TITLE
Modify scontrol data parsing for sstate

### DIFF
--- a/sstate.py
+++ b/sstate.py
@@ -36,7 +36,7 @@ def reformat_scontrol_output(scontrol_output, node_data_list=[]):
     return node_data_list
 
 # This function will filter out unwanted nodes if a partition is specified
-def filter_partition_node_data(node_data_list, partition_node_data_list=[]):
+def filter_partition_node_data(args, node_data_list, partition_node_data_list=[]):
     for node in node_data_list:
         for line in node:
             if line.split("=")[0].strip() == "Partitions":
@@ -236,7 +236,8 @@ def parse_node_data(node_data_list):
                    headers=['Node', 'AllocCPU', 'AvailCPU', 'TotalCPU', 'PercentUsedCPU', 'CPULoad', 'AllocMem', 'AvailMem', 'TotalMem',
                             'PercentUsedMem', 'AllocGPU', 'AvailGPU', 'TotalGPU', 'PercentUsedGPU'], floatfmt=".2f"))
 
-if __name__ == '__main__':
+# Main function
+def main():
     # Parse command line arguments
     args = parse_args()
 
@@ -246,8 +247,12 @@ if __name__ == '__main__':
 
     # If a partition is specified, filter out unwanted nodes from reformatted scontrol output
     if args.partition:
-        node_data_list = filter_partition_node_data(node_data_list)
+        node_data_list = filter_partition_node_data(args, node_data_list)
 
     # Parse through the node data to get available, allocated, and total resources
     # This will also calculate some resource averages and usage percents, as well as print output
     parse_node_data(node_data_list)
+
+# Execute main function
+if __name__ == '__main__':
+    main()

--- a/sstate.py
+++ b/sstate.py
@@ -1,6 +1,5 @@
 #!/bin/env python3
 
-import os
 import argparse
 import subprocess
 import re
@@ -11,12 +10,12 @@ def parse_args():
         description="Query node data in Slurm.",
         usage="""
         # Querying all nodes:
-        {0}
+        sstate
 
         # Querying a specific partition with example:
-        {0} -p $partition_name
-        {0} -p gpu
-        """.format(str(os.path.basename(__file__)))
+        sstate -p $partition_name
+        sstate -p gpu
+        """
     )
     parser.add_argument(
         "-p", "--partition",

--- a/sstate.py
+++ b/sstate.py
@@ -1,10 +1,31 @@
 #!/bin/env python3
 
+import os
 import argparse
 import subprocess
 import re
 from tabulate import tabulate
 
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Query node data in Slurm.",
+        usage="""
+        # Querying all nodes:
+        {0}
+
+        # Querying a specific partition with example:
+        {0} -p $partition_name
+        {0} -p gpu
+        """.format(str(os.path.basename(__file__)))
+    )
+    parser.add_argument(
+        "-p", "--partition",
+        help="Query specific partition. If this is not specified all nodes will be shown.",
+        type=str,
+        metavar=""
+    )
+    args = parser.parse_args()
+    return args
 
 # This function converts MB to larger units
 def human_readable(num, suffix='B'):
@@ -13,14 +34,6 @@ def human_readable(num, suffix='B'):
             return "%3.1f%s%s" % (num, unit, suffix)
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yi', suffix)
-
-
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--partition", help="Specify partition (standard, gpu, largemem, debug, standard-oc). "
-                                                  "If this is not specified all nodes will be shown")
-    args = parser.parse_args()
-    return args
 
 # This function will take the scontrol output and reformat the node data into a list of kv pairs
 # This will allow for better parsing/filtering of the node data later in the script

--- a/sstate.py
+++ b/sstate.py
@@ -35,6 +35,22 @@ def reformat_scontrol_output(scontrol_output, node_data_list=[]):
         node_data_list.append(temp_data_list)
     return node_data_list
 
+# This function will filter out unwanted nodes if a partition is specified
+def filter_partition_node_data(node_data_list, partition_node_data_list=[]):
+    for node in node_data_list:
+        for line in node:
+            if line.split("=")[0].strip() == "Partitions":
+                if args.partition == "debug":
+                    if line.split("=")[1].strip() != "debug":
+                        continue
+                    else:
+                        partition_node_data_list.append(node)
+                else:
+                    for partition in line.split("=")[1].split(","):
+                        if args.partition.lower() == partition.strip():
+                            partition_node_data_list.append(node)
+    return partition_node_data_list
+
 if __name__ == '__main__':
     # Parse command line arguments
     args = parse_args()
@@ -42,6 +58,10 @@ if __name__ == '__main__':
     # Get node data via scontrol and reformat it for easier usability
     scontrol_output = subprocess.check_output("/usr/bin/scontrol show nodes --oneliner", shell=True).decode()
     node_data_list = reformat_scontrol_output(scontrol_output)
+
+    # If a partition is specified, filter out unwanted nodes from reformatted scontrol output
+    if args.partition:
+        node_data_list = filter_partition_node_data(node_data_list)
 
     # Initializes variables to track values
     rows = []


### PR DESCRIPTION
This work is for [TP 87388](https://umarcts.tpondemand.com/RestUI/Board.aspx#page=board/4739735793229175956&appConfig=eyJhY2lkIjoiQTU0Mzc2MDA1QjNCQkI3NDA4MjE1NzdEQTYxNTAzOTIifQ==&boardPopup=bug/87388/silent), and it will:
- add function to reformat scontrol node data to list of kv pairs
- add function to filter out unwanted nodes from reformatted scontrol output
- fix parsing of gres/gpu values to work with reformatted scontrol data
- move node parsing code to its own function
- add main function
- modify arparse function with minor enhancements
- reposition functions for better readability
- minor code syntax changes